### PR TITLE
Remove GDAL pin

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ requirements:
   run:
     - python
     - numpy
-    - gdal 2.1.*
+    - gdal
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   md5: c6d370262a2630ef81deb53b88e5d184
 
 build:
-  number: 2
+  number: 3
   script: python setup.py install
 
 requirements:
@@ -19,7 +19,7 @@ requirements:
   run:
     - python
     - numpy
-    - gdal 2.2.*
+    - gdal 2.1.*
 
 test:
   imports:


### PR DESCRIPTION
Unfortunately `fiona` is not compatible with `gdal 2.2.*` yet, so we need to pin everything to `2.1.*` is we want to install them along side with `fiona`. Note that installing the previous build number with latest `gdal` is still possible when not installing `fiona`.